### PR TITLE
vold: Make exfat driver support generic

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -114,8 +114,8 @@ ifeq ($(TARGET_HW_DISK_ENCRYPTION),true)
   vold_cflags += -DCONFIG_HW_DISK_ENCRYPTION
 endif
 
-ifeq ($(TARGET_KERNEL_HAVE_EXFAT),true)
-  vold_cflags += -DCONFIG_KERNEL_HAVE_EXFAT
+ifneq ($(TARGET_EXFAT_DRIVER),)
+  vold_cflags += -DCONFIG_EXFAT_DRIVER=\"$(TARGET_EXFAT_DRIVER)\"
 endif
 
 ifeq ($(TARGET_KERNEL_HAVE_NTFS),true)

--- a/Android.mk
+++ b/Android.mk
@@ -8,7 +8,6 @@ mini_src_files := \
 	NetlinkManager.cpp \
 	NetlinkHandler.cpp \
 	Process.cpp \
-	fs/Exfat.cpp \
 	fs/Ext4.cpp \
 	fs/F2fs.cpp \
 	fs/Ntfs.cpp \
@@ -116,6 +115,8 @@ endif
 
 ifneq ($(TARGET_EXFAT_DRIVER),)
   vold_cflags += -DCONFIG_EXFAT_DRIVER=\"$(TARGET_EXFAT_DRIVER)\"
+  mini_src_files += fs/Exfat.cpp
+  full_src_files += fs/Exfat.cpp
 endif
 
 ifeq ($(TARGET_KERNEL_HAVE_NTFS),true)

--- a/PublicVolume.cpp
+++ b/PublicVolume.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#ifdef CONFIG_EXFAT_DRIVER
 #include "fs/Exfat.h"
+#endif
 #include "fs/Ext4.h"
 #include "fs/F2fs.h"
 #include "fs/Ntfs.h"
@@ -146,9 +148,12 @@ status_t PublicVolume::doMount() {
     }
 
     int ret = 0;
+#ifdef CONFIG_EXFAT_DRIVER
     if (mFsType == "exfat") {
         ret = exfat::Check(mDevPath);
-    } else if (mFsType == "ext4") {
+    } else
+#endif
+    if (mFsType == "ext4") {
         ret = ext4::Check(mDevPath, mRawPath, false);
     } else if (mFsType == "f2fs") {
         ret = f2fs::Check(mDevPath, false);
@@ -164,10 +169,13 @@ status_t PublicVolume::doMount() {
         return -EIO;
     }
 
+#ifdef CONFIG_EXFAT_DRIVER
     if (mFsType == "exfat") {
         ret = exfat::Mount(mDevPath, mRawPath, false, false, false,
                 AID_MEDIA_RW, AID_MEDIA_RW, 0007);
-    } else if (mFsType == "ext4") {
+    } else
+#endif
+    if (mFsType == "ext4") {
         ret = ext4::Mount(mDevPath, mRawPath, false, false, true, mMntOpts,
                 false, true);
     } else if (mFsType == "f2fs") {
@@ -303,8 +311,10 @@ status_t PublicVolume::doFormat(const std::string& fsType) {
     int ret = 0;
     if (fsType == "auto") {
         ret = vfat::Format(mDevPath, 0);
+#ifdef CONFIG_EXFAT_DRIVER
     } else if (fsType == "exfat") {
         ret = exfat::Format(mDevPath);
+#endif
     } else if (fsType == "ext4") {
         ret = ext4::Format(mDevPath, 0, mRawPath);
     } else if (fsType == "f2fs") {

--- a/fs/Exfat.cpp
+++ b/fs/Exfat.cpp
@@ -33,7 +33,7 @@ namespace exfat {
 
 static const char* kMkfsPath = "/system/bin/mkfs.exfat";
 static const char* kFsckPath = "/system/bin/fsck.exfat";
-#ifdef CONFIG_KERNEL_HAVE_EXFAT
+#ifdef CONFIG_EXFAT_DRIVER
 static const char* kMountPath = "/system/bin/mount";
 #else
 static const char* kMountPath = "/system/bin/mount.exfat";
@@ -74,9 +74,9 @@ status_t Mount(const std::string& source, const std::string& target, bool ro,
 
     std::vector<std::string> cmd;
     cmd.push_back(kMountPath);
-#ifdef CONFIG_KERNEL_HAVE_EXFAT
+#ifdef CONFIG_EXFAT_DRIVER
     cmd.push_back("-t");
-    cmd.push_back("exfat");
+    cmd.push_back(CONFIG_EXFAT_DRIVER);
 #endif
     cmd.push_back("-o");
     cmd.push_back(mountData);

--- a/fs/Exfat.cpp
+++ b/fs/Exfat.cpp
@@ -17,8 +17,14 @@
 #include "Exfat.h"
 #include "Utils.h"
 
+#define LOG_TAG "Vold"
+
 #include <android-base/logging.h>
 #include <android-base/stringprintf.h>
+
+#include <cutils/log.h>
+
+#include <logwrap/logwrap.h>
 
 #include <vector>
 #include <string>
@@ -33,16 +39,10 @@ namespace exfat {
 
 static const char* kMkfsPath = "/system/bin/mkfs.exfat";
 static const char* kFsckPath = "/system/bin/fsck.exfat";
-#ifdef CONFIG_EXFAT_DRIVER
-static const char* kMountPath = "/system/bin/mount";
-#else
-static const char* kMountPath = "/system/bin/mount.exfat";
-#endif
 
 bool IsSupported() {
     return access(kMkfsPath, X_OK) == 0
             && access(kFsckPath, X_OK) == 0
-            && access(kMountPath, X_OK) == 0
             && IsFilesystemSupported("exfat");
 }
 
@@ -57,33 +57,32 @@ status_t Check(const std::string& source) {
 
 status_t Mount(const std::string& source, const std::string& target, bool ro,
         bool remount, bool executable, int ownerUid, int ownerGid, int permMask) {
+    int rc;
+    unsigned long flags;
     char mountData[255];
 
     const char* c_source = source.c_str();
     const char* c_target = target.c_str();
 
-    sprintf(mountData,
-#ifdef CONFIG_KERNEL_HAVE_EXFAT
-            "noatime,nodev,nosuid,uid=%d,gid=%d,fmask=%o,dmask=%o,%s,%s",
-#else
-            "noatime,nodev,nosuid,dirsync,uid=%d,gid=%d,fmask=%o,dmask=%o,%s,%s",
-#endif
-            ownerUid, ownerGid, permMask, permMask,
-            (executable ? "exec" : "noexec"),
-            (ro ? "ro" : "rw"));
+    flags = MS_NODEV | MS_NOSUID | MS_DIRSYNC | MS_NOATIME;
 
-    std::vector<std::string> cmd;
-    cmd.push_back(kMountPath);
-#ifdef CONFIG_EXFAT_DRIVER
-    cmd.push_back("-t");
-    cmd.push_back(CONFIG_EXFAT_DRIVER);
-#endif
-    cmd.push_back("-o");
-    cmd.push_back(mountData);
-    cmd.push_back(c_source);
-    cmd.push_back(c_target);
+    flags |= (executable ? 0 : MS_NOEXEC);
+    flags |= (ro ? MS_RDONLY : 0);
+    flags |= (remount ? MS_REMOUNT : 0);
 
-    return ForkExecvp(cmd);
+    snprintf(mountData, sizeof(mountData),
+            "uid=%d,gid=%d,fmask=%o,dmask=%o",
+            ownerUid, ownerGid, permMask, permMask);
+
+    rc = mount(c_source, c_target, CONFIG_EXFAT_DRIVER, flags, mountData);
+
+    if (rc && errno == EROFS) {
+        SLOGE("%s appears to be a read only filesystem - retrying mount RO", c_source);
+        flags |= MS_RDONLY;
+        rc = mount(c_source, c_target, CONFIG_EXFAT_DRIVER, flags, mountData);
+    }
+
+    return rc;
 }
 
 status_t Format(const std::string& source) {


### PR DESCRIPTION
* Samsung moved to a new driver in their recent devices,
  and inevitably there will be more in the future
* Make our support generic with the flag TARGET_EXFAT_DRIVER=foo,
  where foo is the -t arg the fs needs to be mounted with

Change-Id: I984481972bf79bf195321e69906cc5994fb19f2d